### PR TITLE
Refactor MarshalCopy to use unsafe block and avoid unnecessary memory allocation

### DIFF
--- a/ArrayCopyBenchmark/ArrayCopyBenchmark.csproj
+++ b/ArrayCopyBenchmark/ArrayCopyBenchmark.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ArrayCopyBenchmark/CopyBenchmark.cs
+++ b/ArrayCopyBenchmark/CopyBenchmark.cs
@@ -54,13 +54,13 @@ namespace ArrayCopyBenchmark
 
         [Benchmark]
         [ArgumentsSource(nameof(GetIntArray))]
-        public void MarshalCopy(int[] array)
+        public unsafe void MarshalCopy(int[] array)
         {
-            int size = 4 * array.Length;
-            IntPtr ptr = Marshal.AllocHGlobal(size);
-            Marshal.Copy(array, 0, ptr, array.Length);
-            Marshal.Copy(ptr, Destination, 0, array.Length);
-            Marshal.FreeHGlobal(ptr);
+            fixed (int* dstPtr = Destination)
+            {
+                IntPtr ptr = (IntPtr)dstPtr;
+                Marshal.Copy(array, 0, ptr, array.Length);
+            }
         }
     }
 }


### PR DESCRIPTION
Refactored MarshalCopy to eliminate the redundant use of Marshal.AllocHGlobal and Marshal.FreeHGlobal. The new implementation leverages an unsafe block with a fixed pointer to directly access the destination memory, improving performance by avoiding extra memory allocations. This simplifies the code and ensures safer and more efficient memory handling without the need for manual heap allocation.